### PR TITLE
Fix spelling of "JavaScript"

### DIFF
--- a/src/omnitone-home.html
+++ b/src/omnitone-home.html
@@ -222,7 +222,7 @@
     </div>
 
     <div class="section text">
-      <p><strong>Omnitone</strong> is a Javascript implementation of a 
+      <p><strong>Omnitone</strong> is a JavaScript implementation of a 
         <strong>first-order ambisonic</strong> decoder that allows you to
         <strong>binaurally render</strong> an ambisonic recording directly on
         the browser.</p>


### PR DESCRIPTION
"JavaScript" is CamelCase

https://en.wikipedia.org/wiki/JavaScript