### PR TITLE
add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+examples/


### PR DESCRIPTION
Fixes #30 
This should address the large package size in npm by using a `.npmignore` file.
