### PR TITLE
Update the HRTFSET_URL param in the foa decoder to point this repository.

### DIFF
--- a/src/foa-decoder.js
+++ b/src/foa-decoder.js
@@ -30,7 +30,7 @@ var Utils = require('./utils.js');
 var SystemVersion = require('./version.js');
 
 // By default, Omnitone fetches IR from the spatial media repository.
-var HRTFSET_URL = 'https://raw.githubusercontent.com/google/spatial-media/master/support/hrtfs/cube/';
+var HRTFSET_URL = 'https://raw.githubusercontent.com/GoogleChrome/omnitone/master/src/resources/';
 
 // Post gain compensation value.
 var POST_GAIN_DB = 0;


### PR DESCRIPTION
This is a permanent fix to #47 

Since https://github.com/google/spatial-media/commit/7da0a1ef40f2e306d467123d11b193471acbdb04 the wav files are no longer present on the spatial-media repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlechrome/omnitone/48)
<!-- Reviewable:end -->
