### PR TITLE
Fixed documentation for npm test on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,11 +291,7 @@ npm test
 Note that unit tests require the promisified version of `OfflineAudioContext`, so they might not run on outdate browsers. Omnitone's Travis CI is using the latest stable version of Chrome.
 
 ##### Linux (Tested with Ubuntu 16.04)
-The Karma system calls two env variables "node" and "CHROME_BIN" that may not be defined on your system. The node variable can be properly called after installing the nodejs-legacy package through apt: (Note this package name may differ for your distro)
-
-```bash
-sudo apt install nodejs-legacy
-```
+The Karma system calls two env variables "node" and "CHROME_BIN" that may not be defined on your system. The node variable can be properly called after installing the latest version of nodejs as described [HERE](https://github.com/nodesource/distributions).
 
 You should also install the chromium-browser package through apt: 
 


### PR DESCRIPTION
Now includes latest version of NodeJS rather than relying on a legacy version.

Related Issue:
https://github.com/GoogleChrome/omnitone/issues/51